### PR TITLE
Fix Chroniton links

### DIFF
--- a/Week12/README.md
+++ b/Week12/README.md
@@ -9,7 +9,7 @@
 
 FYI: New home for the chroniton.js play/pause d3 slider control is here:
 
-* http://xaranke.github.io/chroniton/example/index.html
+* https://arankek.github.io/chroniton/example/index.html
 
 
 ### Reminders about Bugs
@@ -332,5 +332,3 @@ Send me the link to your updated repo, with:
  * code in functions and different js files as we discussed today,
  * and some text/layout that outlines the story you will tell in your project.
  * In other words, show me progress.
-
-

--- a/Week12/index.html
+++ b/Week12/index.html
@@ -62,7 +62,7 @@
 <h3 id="chroniton.js-slider-moved">Chroniton.js Slider Moved</h3>
 <p>FYI: New home for the chroniton.js play/pause d3 slider control is here:</p>
 <ul>
-<li><a href="http://xaranke.github.io/chroniton/example/index.html" class="uri">http://xaranke.github.io/chroniton/example/index.html</a></li>
+<li><a href="https://arankek.github.io/chroniton/example/index.html" class="uri">http://arankek.github.io/chroniton/example/index.html</a></li>
 </ul>
 <h3 id="reminders-about-bugs">Reminders about Bugs</h3>
 <p>Things to check for:</p>

--- a/Week13/README.md
+++ b/Week13/README.md
@@ -101,7 +101,7 @@ See [animation_end.html](animation_end.html) for an example of chained transitio
 ## UI Sliders for Timelines
 
 Tom MacWright's control that I recommend (it has changed maintenance/ownership):
-http://xaranke.github.io/chroniton/example/index.html.
+https://arankek.github.io/chroniton/example/index.html.
 
 See my example use of it in **[africa_map_slider.html](africa_map_slider.html).** It has options for configuring it to restart playing, etc.
 
@@ -207,6 +207,3 @@ Send me the link to the repo. Make sure it has an index page. Put the CSVs for y
 **Homework 2 (25pt) Two Graphs on a Page!**
 
 Make two charts for your project, on the same page.  Use functions to structure this, so the variables don't stomp on each other.  I won't be judging the content of the vis yet, just structure and making sure they "work" on the same page.
-
-
-

--- a/Week13/index.html
+++ b/Week13/index.html
@@ -120,7 +120,7 @@
 <p>See <a href="animation_end.html" class="uri">animation_end.html</a> for an example of chained transitions, where one starts after another, on the same &quot;object&quot;.</p>
 <h2 id="ui-sliders-for-timelines">UI Sliders for Timelines</h2>
 <p>Tom MacWright's control that I recommend (it has changed maintenance/ownership):<br />
-<a href="http://xaranke.github.io/chroniton/example/index.html" class="uri">http://xaranke.github.io/chroniton/example/index.html</a>.</p>
+<a href="https://arankek.github.io/chroniton/example/index.html" class="uri">https://arankek.github.io/chroniton/example/index.html</a>.</p>
 <p>See my example use of it in <strong><a href="africa_map_slider.html" class="uri">africa_map_slider.html</a>.</strong> It has options for configuring it to restart playing, etc.</p>
 <p>More related items:</p>
 <ul>


### PR DESCRIPTION
xaranke has changed his username to @arankek, so the urls were broken. This should fix that. 

Old link (broken): http://xaranke.github.io/chroniton/example/index.html
New link: https://arankek.github.io/chroniton/example/index.html

Thanks for this great course!